### PR TITLE
Ensure included file names match case of files

### DIFF
--- a/Fast Track/functions/file_1_trackAutoselect.praat
+++ b/Fast Track/functions/file_1_trackAutoselect.praat
@@ -3,7 +3,7 @@
 ########################################################################################################################################################
 ## Initial setup
 
-include utils/importfunctions.praat
+include utils/importFunctions.praat
 
 
 snd = selected ()

--- a/Fast Track/functions/file_2_editTracks.praat
+++ b/Fast Track/functions/file_2_editTracks.praat
@@ -2,7 +2,7 @@
 snd = selected ("Sound")
 fr = selected ("Formant")
 
-include utils/importfunctions.praat
+include utils/importFunctions.praat
 @getSettings
 
 beginPause: "Set Parameters"

--- a/Fast Track/functions/file_3_plotTable.praat
+++ b/Fast Track/functions/file_3_plotTable.praat
@@ -3,7 +3,7 @@
 snd = selected ("Sound")
 tbl = selected ("Table")
 
-include utils/importfunctions.praat
+include utils/importFunctions.praat
 
 @getSettings
 beginPause: "Set Parameters"

--- a/Fast Track/functions/file_4_plotFormants.praat
+++ b/Fast Track/functions/file_4_plotFormants.praat
@@ -12,7 +12,7 @@
 tbl = selected ("Table")
 basename$ = selected$ ("Table")
 
-include utils/importfunctions.praat
+include utils/importFunctions.praat
 
 clicked = 2
 plotting_symbol$ = "a"

--- a/Fast Track/functions/file_5_extractVowelswithTG.praat
+++ b/Fast Track/functions/file_5_extractVowelswithTG.praat
@@ -5,7 +5,7 @@ tg = selected ("TextGrid")
 snd = selected ("Sound")
 basename$ = selected$ ("Sound")
 
-include utils/importfunctions.praat
+include utils/importFunctions.praat
 @getSettings
 
 @getTGESettings

--- a/Fast Track/functions/folder_1_analyzeFolder.praat
+++ b/Fast Track/functions/folder_1_analyzeFolder.praat
@@ -1,7 +1,7 @@
 
 ## collect all regression coefficients in one big csv file. recreate after, collect winners,
 
-include utils/importfunctions.praat
+include utils/importFunctions.praat
 include folder/trackFolder.praat
 include folder/autoSelectFolder.praat
 include folder/getWinnersFolder.praat

--- a/Fast Track/functions/folder_2_tools.praat
+++ b/Fast Track/functions/folder_2_tools.praat
@@ -1,6 +1,6 @@
 
 
-include utils/importfunctions.praat
+include utils/importFunctions.praat
 
 tables# = selected# ("Table")
 

--- a/Fast Track/functions/folder_3_plotAggregate.praat
+++ b/Fast Track/functions/folder_3_plotAggregate.praat
@@ -9,7 +9,7 @@
 ########################################################################################################################################################
 ## Initial setup
 
-include utils/importfunctions.praat
+include utils/importFunctions.praat
 
 
 tbl = selected ("Table")

--- a/Fast Track/functions/proc_textGridChopper.praat
+++ b/Fast Track/functions/proc_textGridChopper.praat
@@ -5,7 +5,7 @@ tg = selected ("TextGrid")
 snd = selected ("Sound")
 basename$ = selected$ ("Sound")
 
-include utils/importfunctions.praat
+include utils/importFunctions.praat
 @getSettings
 
 # set parameter for specifying vowels. make table

--- a/Fast Track/functions/utils/importFunctions.praat
+++ b/Fast Track/functions/utils/importFunctions.praat
@@ -15,7 +15,7 @@ include utils/getTGESettings.praat
 include utils/saveTGESettings.praat
 
 include tools/aggregate.praat
-include tools/aggregateAggregate.praat
+include tools/aggregateaggregate.praat
 include tools/aggregateTables.praat
 include tools/addBuffer.praat
 include tools/findOutliers.praat


### PR DESCRIPTION
I'm trying this out on Ubuntu 20.04 Praat 6.1.09, and when pressing buttons, I was getting errors about not being about to open scripts.

Investigation revealed that some includes disagreed in their camelCasing with the file name. These changes tweak the includes so that the case of the file name matches the file system, so that the buttons work on OS's with case-sensitive file names.