### PR TITLE
trackAutoselect procedure

### DIFF
--- a/Fast Track/functions/file_1_trackAutoselect.praat
+++ b/Fast Track/functions/file_1_trackAutoselect.praat
@@ -3,7 +3,7 @@
 ########################################################################################################################################################
 ## Initial setup
 
-include utils/importFunctions.praat
+include utils/trackAutoselectProcedure.praat
 
 snd = selected ()
 basename$ = selected$ ("Sound")
@@ -150,234 +150,53 @@ if analyze_selection == 1
 endif
 
 
-########################################################################################################################################################
-########################################################################################################################################################
-## Error estimation section
+sound_to_plot = snd
+sound_to_analyse = snd
+if analyze_selection == 1
+  sound_to_analyse = tmp_snd
+  if plot_in_context == 0
+    sound_to_plot = tmp_snd
+  endif
+endif
 
-# error related variables
-formantError# = zero#(number_of_formants)
-totalError = 0
-minerror = 999999
-error# =  zero# (number_of_steps)
-cutoffs# = zero#(number_of_steps)
-
-# determine analysis frequencies given number of steps and cutoffs
-stepSize = (highest_analysis_frequency-lowest_analysis_frequency) / (number_of_steps-1)
-for i from 1 to number_of_steps
-  cutoffs#[i] = round (lowest_analysis_frequency+stepSize*(i-1))
-endfor
+# what kind of output is selected? 1=save, 2=return, 3=both
+output_formant = save_formant
+if return_formant = 1
+  output_formant = output_formant + 2
+endif
+output_table = save_csv
+if return_table = 1
+  output_table = output_table + 2
+endif
+plot_current_view = 0
+if what_to_track = 2
+  plot_current_view = 1
+endif
 
 # I need to change this to something more useful like the winning regression coefficients or something
 writeInfoLine: "Analyzing..."
 
-winner = 1
+# do the analysis and get the output
+@trackAutoselect: sound_to_analyse, folder$, lowest_analysis_frequency, highest_analysis_frequency, number_of_steps, number_of_coefficients_for_formant_prediction, number_of_formants, tracking_method$, image, sound_to_plot, plot_current_view, maximum_plotting_frequency, output_formant, output_table, save_all_formants
 
-## loop that performs the analyses
-for z from 1 to number_of_steps
-  appendInfoLine: z
-	selectObject: snd
-
-    if analyze_selection == 1
-      selectObject: tmp_snd
-    endif
-
-  # analysis of sounds
-	if tracking_method$ == "burg"
-    noprogress To Formant (burg): time_step, 5.5, cutoffs#[z], 0.025, 50
-  endif
-  if tracking_method$ == "robust"
-    noprogress To Formant (robust): time_step, 5.5, cutoffs#[z], 0.025, 50, 1.5, 5, 1e-006
-  endif
-  Rename: "formants_" + string$(z)
-  formantObject = selected ("Formant")
-
-  # this is where the contours actually get modeled. check this function out for info.
-  # it also created a lot of useful variables like the coefficient and error vectors that get used below.
-  # in praat these are all global variables, functions dont return results. 
-	@findError: formantObject
-	Rename: "formants_" + string$(z)
-
-  # if current step minimizes the error, make it the new winner
-  if error#[z] <  minerror
-	  winner = z
-	  cutoff = cutoffs#[z]
-	  minerror = error#[z]
-
-    # store regression coefficients for output in info window
-    tmp_f1coeffs# = f1coeffs#
-    tmp_f2coeffs# = f2coeffs#
-    tmp_f3coeffs# = f3coeffs#
-    if number_of_formants == 4
-      tmp_f4coeffs# = f4coeffs#
-    endif
-  endif
-
-  error#[z] = sum(formantError#)
-  error#[z] = round (error#[z] * 10) / 10
-  
-endfor
-
-writeInfoLine: "Best cutoff is: " + string$(cutoff)
+writeInfoLine: "Best cutoff is: " + string$(trackAutoselect.cutoff)
 appendInfoLine: ""
 appendInfoLine: "F1 coefficients: "
-appendInfoLine: tmp_f1coeffs#
+appendInfoLine: trackAutoselect.f1coeffs#
 appendInfoLine: "F2 coefficients: "
-appendInfoLine: tmp_f2coeffs#
+appendInfoLine: trackAutoselect.f2coeffs#
 appendInfoLine: "F3 coefficients: "
-appendInfoLine: tmp_f3coeffs#
+appendInfoLine: trackAutoselect.f3coeffs#
 if number_of_formants == 4
   appendInfoLine: "F4 coefficients: "
-  appendInfoLine: tmp_f4coeffs#
+  appendInfoLine: trackAutoselect.f4coeffs#
 endif
 appendInfoLine: ""
 appendInfoLine: "The first number in each row (the intercept) is a good estimate of the"
 appendInfoLine: "frequency of the formant at the analysis midpoint. The second number indicates"
 appendInfoLine: "its linear slope, the third its quadratic component (u-shapedness), ... etc."
 
-
-########################################################################################################################################################
-########################################################################################################################################################
-## Plot
-
-if image = 1
-  Erase all
-  Select outer viewport: 0, 7.5, 0, 4.5
-  selectObject: "Table formants_" + string$(winner)
-  tbl = selected ("Table")
-  selectObject: snd
-  if plot_in_context == 0
-    selectObject: tmp_snd
-  endif
-
-  ## if NOT current view
-  if what_to_track <> 2
-    sp = To Spectrogram: 0.007, maximum_plotting_frequency, 0.002, 5, "Gaussian"
-	  @plotTable: sp, tbl, maximum_plotting_frequency, 1, "Maximum formant = " + string$(cutoff) + " Hz"
-    removeObject: sp
-  endif
-
-  # if YEs current view, this needs to grab the current spectrogram from the view window and plot it.
-  # analysis also needs to be scaled to the frequency limit of the view so that these match. 
-  if what_to_track == 2
-    editor: snd
-	  sp = Extract visible spectrogram
-	  info$ = Editor info
-  	maximum_plotting_frequency = extractNumber (info$, "Spectrogram view to: ")
-    endeditor
-    selectObject: sp
-	  @plotTable: sp, tbl, maximum_plotting_frequency, 1, "Maximum formant = " + string$(cutoff) + " Hz"
-    removeObject: sp
-	endif
-  # change to save with filename or not
-  Save as 300-dpi PNG file: folder$ + "/file_winner.png"
- endif
-
- # this is for the comparison images. pretty straightforward
- if image = 2
-	  Erase all
-	  selectObject: snd
-
-    if analyze_selection == 1
-      selectObject: tmp_snd
-    endif
-
-	 sp = To Spectrogram: 0.007, maximum_plotting_frequency, 0.002, 5, "Gaussian"
-
-	 width = 2.85
-	 xlims# = {0,width, width*2,width*3,0,width, width*2,width*3,0,width, width*2, width*3,0,width, width*2, width*3,0,width, width*2, width*3,0,width, width*2, width*3}
-	 ylims# = {0,0,0,0,2,2,2,2,4,4,4,4,6,6,6,6,8,8,8,8,10,10,10,10}
-
-	 for z from 1 to number_of_steps
-		 Select outer viewport: xlims#[z], xlims#[z]+3.2, ylims#[z], ylims#[z]+2
-		 selectObject: "Table formants_" + string$(z)
-		 tbl = selected ("Table")
-     Font size: 8
-	   @plotTable: sp, tbl, maximum_plotting_frequency, 1, "Maximum formant = " + string$(cutoffs#[z]) + " Hz"
-
-		 if z = winner
-       Line width: 4
-       Draw inner box
-       Line width: 1
-		 endif
-	 endfor
-
-	 Font size: 10
-	 if number_of_steps = 8
-		 Select outer viewport: 0, 12, 0, 4
-	 elsif number_of_steps = 12
-		 Select outer viewport: 0, 12, 0, 6
-	 elsif number_of_steps = 16
-		 Select outer viewport: 0, 12, 0, 8
-	 elsif number_of_steps = 20
-		 Select outer viewport: 0, 12, 0, 10
-	 elsif number_of_steps = 24
-		 Select outer viewport: 0, 12, 0, 12
-	 endif
-	 Save as 300-dpi PNG file: folder$ + "/file_comparison.png"
- endif
-nocheck removeObject: sp
-
-########################################################################################################################################################
-########################################################################################################################################################
-## Save data and delete backup files. nothing fancy here. a lot of removing objects
-
-
-for z from 1 to number_of_steps
-	if (save_formant = 1 or save_all_formants = 1) and z = winner
-		selectObject: "Formant formants_" + string$(z)
-		Save as short text file: folder$ + "/" + basename$ + "_" + string$(winner) +"_.Formant"
-	endif
-	if save_all_formants = 1 and z <> winner
-		selectObject: "Formant formants_" + string$(z)
-		Save as short text file: folder$ + "/" + basename$ + "_" + string$(z) +"_.Formant"
-	endif
-endfor
-
-if save_csv = 1 or return_table = 1
-	selectObject: "Table formants_" + string$(winner)
-	tbl = selected ("Table")
-	@addAcousticInfoToTable: tbl, snd  
-
-  for .i from 1 to number_of_formants
-    if output_bandwidth == 0
-      Remove column... b'.i'
-    endif
-    if output_predictions == 0
-      Remove column... f'.i'p
-    endif
-  endfor
-
-  if output_normalized_time == 0
-    Insert column: 2, "ntime"
-    Formula: "ntime", "row / nrow"
-  endif
-
-endif
-
-if save_csv = 1
-	selectObject: "Table formants_" + string$(winner)
-	Save as comma-separated file: folder$ + "/" + basename$ + ".csv"
-endif
-
-if return_table = 0
-	selectObject: "Table formants_" + string$(winner)
-	Remove
-else
-	selectObject: "Table formants_" + string$(winner)
-	Rename: basename$
-endif
-
-for z from 1 to number_of_steps
- if z = winner
-	 if return_formant = 1
-		 selectObject: "Formant formants_" + string$(z)
-		 Rename: basename$
-	 endif
- endif
- nocheck removeObject: "Formant formants_" + string$(z)
- nocheck removeObject: "Table formants_" + string$(z)
-endfor
-
+# tidy up
 if analyze_selection == 1
   removeObject: tmp_snd
 endif

--- a/Fast Track/functions/folder/autoSelectFolder.praat
+++ b/Fast Track/functions/folder/autoSelectFolder.praat
@@ -133,7 +133,7 @@ procedure autoSelectFolder
       ##################################################################################
       ## this part determines the winner
 
-  	  @findError: .fr
+  	  @findError: .fr, number_of_coefficients_for_formant_prediction
       .totalerror#[.z] = sum(formantError#)
       .totalerror#[.z] = round (.totalerror#[.z] * 10) / 10
       .f1Error#[.z] = formantError#[1]

--- a/Fast Track/functions/folder/autoSelectFolder.praat
+++ b/Fast Track/functions/folder/autoSelectFolder.praat
@@ -133,7 +133,7 @@ procedure autoSelectFolder
       ##################################################################################
       ## this part determines the winner
 
-  	  @findError: .fr, number_of_coefficients_for_formant_prediction
+  	  @findError: .fr, number_of_coefficients_for_formant_prediction, number_of_formants
       .totalerror#[.z] = sum(formantError#)
       .totalerror#[.z] = round (.totalerror#[.z] * 10) / 10
       .f1Error#[.z] = formantError#[1]

--- a/Fast Track/functions/folder/getWinnersFolder.praat
+++ b/Fast Track/functions/folder/getWinnersFolder.praat
@@ -175,7 +175,7 @@ procedure getWinnersFolder
 	  	.tmp_fr = Read from file: folder$ + "/formants/"+ .basename$ + "_" + string$(.winner) + "_.Formant"
 	   	Save as short text file: folder$ + "/formants_winners/" + .basename$ + "_winner_.Formant"
 
-		  @findError: .tmp_fr, number_of_coefficients_for_formant_prediction
+		  @findError: .tmp_fr, number_of_coefficients_for_formant_prediction, number_of_formants
 			for .jj from 1 to (number_of_coefficients_for_formant_prediction+1)
 				winf1coeffs#[.jj] = f1coeffs#[.jj]
 				winf2coeffs#[.jj] = f2coeffs#[.jj]
@@ -236,7 +236,7 @@ procedure getWinnersFolder
 
 	    selectObject: .tmp_f1
 	    Save as short text file: folder$ + "/formants_winners/" + .basename$ + "_winner_.Formant"
-			@findError: .tmp_f1, number_of_coefficients_for_formant_prediction
+			@findError: .tmp_f1, number_of_coefficients_for_formant_prediction, number_of_formants
 			for .jj from 1 to (number_of_coefficients_for_formant_prediction+1)
 				winf1coeffs#[.jj] = f1coeffs#[.jj]
 				winf2coeffs#[.jj] = f2coeffs#[.jj]

--- a/Fast Track/functions/folder/getWinnersFolder.praat
+++ b/Fast Track/functions/folder/getWinnersFolder.praat
@@ -175,7 +175,7 @@ procedure getWinnersFolder
 	  	.tmp_fr = Read from file: folder$ + "/formants/"+ .basename$ + "_" + string$(.winner) + "_.Formant"
 	   	Save as short text file: folder$ + "/formants_winners/" + .basename$ + "_winner_.Formant"
 
-		  @findError: .tmp_fr
+		  @findError: .tmp_fr, number_of_coefficients_for_formant_prediction
 			for .jj from 1 to (number_of_coefficients_for_formant_prediction+1)
 				winf1coeffs#[.jj] = f1coeffs#[.jj]
 				winf2coeffs#[.jj] = f2coeffs#[.jj]
@@ -236,7 +236,7 @@ procedure getWinnersFolder
 
 	    selectObject: .tmp_f1
 	    Save as short text file: folder$ + "/formants_winners/" + .basename$ + "_winner_.Formant"
-			@findError: .tmp_f1
+			@findError: .tmp_f1, number_of_coefficients_for_formant_prediction
 			for .jj from 1 to (number_of_coefficients_for_formant_prediction+1)
 				winf1coeffs#[.jj] = f1coeffs#[.jj]
 				winf2coeffs#[.jj] = f2coeffs#[.jj]

--- a/Fast Track/functions/modeling/findError.praat
+++ b/Fast Track/functions/modeling/findError.praat
@@ -1,5 +1,5 @@
 
-procedure findError .fr, .number_of_coefficients_for_formant_prediction
+procedure findError .fr, .number_of_coefficients_for_formant_prediction, .number_of_formants
 
   ####################################################################################
   # sets up table called output that will contain all information abotu values, prediction, error, etc.
@@ -20,7 +20,7 @@ procedure findError .fr, .number_of_coefficients_for_formant_prediction
     Set column label (label): "B"+string$(.i)+"(Hz)", "b"+string$(.i)
   endfor
 
-  if number_of_formants == 3
+  if .number_of_formants == 3
     Remove column: "b4"
     Remove column: "f4"
   endif
@@ -29,7 +29,7 @@ procedure findError .fr, .number_of_coefficients_for_formant_prediction
   Append column: "f2p"
   Append column: "f3p"
 
-  if number_of_formants == 4
+  if .number_of_formants == 4
     Append column: "f4p"
   endif
 
@@ -57,12 +57,12 @@ procedure findError .fr, .number_of_coefficients_for_formant_prediction
   f1coeffs# = zero# (.number_of_coefficients_for_formant_prediction+1)
   f2coeffs# = zero# (.number_of_coefficients_for_formant_prediction+1)
   f3coeffs# = zero# (.number_of_coefficients_for_formant_prediction+1)
-  if number_of_formants == 4
+  if .number_of_formants == 4
     f4coeffs# = zero# (.number_of_coefficients_for_formant_prediction+1)
   endif
 
-  for .fnum from 1 to number_of_formants
-    @predictFormants: .fnum, .number_of_coefficients_for_formant_prediction
+  for .fnum from 1 to .number_of_formants
+    @predictFormants: .fnum, .number_of_coefficients_for_formant_prediction, .number_of_formants
     f'.fnum'coeffs#[1] = round (intercept * 10) / 10
     for .cnum from 1 to .number_of_coefficients_for_formant_prediction
       f'.fnum'coeffs#[.cnum+1] = round(coeff'.cnum' * 10) / 10
@@ -78,13 +78,13 @@ procedure findError .fr, .number_of_coefficients_for_formant_prediction
   ###############################################################################
   ### Here is where the error is calculated. 
 
-  formantError# = zero#(number_of_formants)
+  formantError# = zero#(.number_of_formants)
   totalerror = 0
   select Table output
   Formula: "error1", "abs(self)"
   Formula: "error2", "abs(self)"
   Formula: "error3", "abs(self)"
-  if number_of_formants == 4
+  if .number_of_formants == 4
     Formula: "error4", "abs(self)"
   endif
   ;.tmp = Get quantile: "error1", 0.5
@@ -96,7 +96,7 @@ procedure findError .fr, .number_of_coefficients_for_formant_prediction
   ;.tmp = Get quantile: "error3", 0.5
   .tmp = Get mean: "error3"
   formantError#[3] = round((.tmp)*10)/10
-  if number_of_formants == 4
+  if .number_of_formants == 4
     ;.tmp = Get quantile: "error4", 0.5
     .tmp = Get mean: "error4"
     formantError#[4] = round((.tmp)*10)/10
@@ -132,7 +132,7 @@ procedure findError .fr, .number_of_coefficients_for_formant_prediction
     formantError#[3] = formantError#[3] + 10000
   endif
 
-  if number_of_formants == 4
+  if .number_of_formants == 4
     tmp1 = Get quantile: "f1", 0.5
     tmp2 = Get quantile: "f2", 0.5
     tmp3 = Get quantile: "f3", 0.5
@@ -145,7 +145,7 @@ procedure findError .fr, .number_of_coefficients_for_formant_prediction
     endif
   endif
 
-  for .ff from 1 to number_of_formants
+  for .ff from 1 to .number_of_formants
     Remove column... error'.ff'
   endfor
   Remove column... frame

--- a/Fast Track/functions/modeling/findError.praat
+++ b/Fast Track/functions/modeling/findError.praat
@@ -1,5 +1,5 @@
 
-procedure findError .fr
+procedure findError .fr, .number_of_coefficients_for_formant_prediction
 
   ####################################################################################
   # sets up table called output that will contain all information abotu values, prediction, error, etc.
@@ -44,7 +44,7 @@ procedure findError .fr
   Formula: "time1", "row / number_of_frames"
   Formula: "time1", "cos(( self )*pi*2*(1*0.5))"
 
-  for .c from 2 to number_of_coefficients_for_formant_prediction
+  for .c from 2 to .number_of_coefficients_for_formant_prediction
     select Table output
     Append column... time'.c'
     Formula: "time"+string$(.c), "row / " + string$(number_of_frames)
@@ -54,24 +54,24 @@ procedure findError .fr
   ####################################################################################
   ## prediction of formant values and collections of prediction coefficients
 
-  f1coeffs# = zero# (number_of_coefficients_for_formant_prediction+1)
-  f2coeffs# = zero# (number_of_coefficients_for_formant_prediction+1)
-  f3coeffs# = zero# (number_of_coefficients_for_formant_prediction+1)
+  f1coeffs# = zero# (.number_of_coefficients_for_formant_prediction+1)
+  f2coeffs# = zero# (.number_of_coefficients_for_formant_prediction+1)
+  f3coeffs# = zero# (.number_of_coefficients_for_formant_prediction+1)
   if number_of_formants == 4
-    f4coeffs# = zero# (number_of_coefficients_for_formant_prediction+1)
+    f4coeffs# = zero# (.number_of_coefficients_for_formant_prediction+1)
   endif
 
   for .fnum from 1 to number_of_formants
-    @predictFormants: .fnum
+    @predictFormants: .fnum, .number_of_coefficients_for_formant_prediction
     f'.fnum'coeffs#[1] = round (intercept * 10) / 10
-    for .cnum from 1 to number_of_coefficients_for_formant_prediction
+    for .cnum from 1 to .number_of_coefficients_for_formant_prediction
       f'.fnum'coeffs#[.cnum+1] = round(coeff'.cnum' * 10) / 10
     endfor
   endfor
 
   ## predictor information no longer needed in output. it was only there to speed up prediction
   select Table output
-  for .ff from 1 to number_of_coefficients_for_formant_prediction
+  for .ff from 1 to .number_of_coefficients_for_formant_prediction
     Remove column... time'.ff'
   endfor
 

--- a/Fast Track/functions/modeling/predictFormants.praat
+++ b/Fast Track/functions/modeling/predictFormants.praat
@@ -1,5 +1,5 @@
 
-procedure predictFormants .ff
+procedure predictFormants .ff, .number_of_coefficients_for_formant_prediction
   selectObject: "Table output"
   Copy: "regression"
   Remove column... frame
@@ -23,7 +23,7 @@ procedure predictFormants .ff
   #Append column... f'.ff'p
   #Formula... f'.ff'p intercept
 
-  for .c from 1 to number_of_coefficients_for_formant_prediction
+  for .c from 1 to .number_of_coefficients_for_formant_prediction
     coeff'.c' = extractNumber (info$, "Coefficient of factor time" + string$(.c)+ ": ")
     select Table output
     Formula... f'.ff'p self + self[row,"time"+string$(.c)] * coeff'.c'
@@ -54,7 +54,7 @@ procedure predictFormants .ff
   #select Table output
   #Formula... f'.ff'p intercept
 
-  #for .c from 1 to number_of_coefficients_for_formant_prediction
+  #for .c from 1 to .number_of_coefficients_for_formant_prediction
   #  coeff'.c' = extractNumber (info$, "Coefficient of factor time" + string$(.c)+ ": ")
   #  select Table output
   #  Formula... f'.ff'p self + self[row,"time"+string$(.c)] * coeff'.c'

--- a/Fast Track/functions/modeling/predictFormants.praat
+++ b/Fast Track/functions/modeling/predictFormants.praat
@@ -1,5 +1,5 @@
 
-procedure predictFormants .ff, .number_of_coefficients_for_formant_prediction
+procedure predictFormants .ff, .number_of_coefficients_for_formant_prediction, .number_of_formants
   selectObject: "Table output"
   Copy: "regression"
   Remove column... frame
@@ -7,7 +7,7 @@ procedure predictFormants .ff, .number_of_coefficients_for_formant_prediction
   Append column... formant
   Formula... formant self[row,"f"+string$(.ff)]
 
-  for .i from 1 to number_of_formants
+  for .i from 1 to .number_of_formants
     Remove column... f'.i'
     Remove column... b'.i'
     Remove column... f'.i'p

--- a/Fast Track/functions/utils/editTracks.praat
+++ b/Fast Track/functions/utils/editTracks.praat
@@ -5,7 +5,7 @@ procedure editTracks: fr
   .clicked = 0
   while .clicked <> 1
     totalerror = 0
-    @findError: fr
+    @findError: fr, number_of_coefficients_for_formant_prediction
     selectObject: "Table output"
     tbl = selected ("Table")
     .nrows = Get number of rows

--- a/Fast Track/functions/utils/trackAutoselectProcedure.praat
+++ b/Fast Track/functions/utils/trackAutoselectProcedure.praat
@@ -84,7 +84,7 @@ procedure trackAutoselect: .snd, .folder$, .lowest_analysis_frequency, .highest_
     # this is where the contours actually get modeled. check this function out for info.
     # it also created a lot of useful variables like the coefficient and error vectors that get used below.
     # in praat these are all global variables, functions dont return results. 
-    @findError: .formantObject, .number_of_coefficients_for_formant_prediction
+    @findError: .formantObject, .number_of_coefficients_for_formant_prediction, .number_of_formants
     Rename: "formants_" + string$(z)
   
     # if current step minimizes the error, make it the new winner

--- a/Fast Track/functions/utils/trackAutoselectProcedure.praat
+++ b/Fast Track/functions/utils/trackAutoselectProcedure.praat
@@ -1,0 +1,250 @@
+include utils/importFunctions.praat
+
+# procedure for performing analysis with no user interaction
+# parameters:
+# - .snd: sound object to analyse.
+# - .folder$: path to directory for temporary files and final results files.
+# - .lowest_analysis_frequency: Lowest analysis frequency (Hz).
+# - .highest_analysis_frequency: Highest analysis frequency (Hz).
+# - .number_of_steps: the analyses between low and high analysis limits. More analysis
+#      steps may improve results, but will increase.
+# - .number_of_coefficients_for_formant_prediction: More coefficients allow for more
+#      sudden, and 'wiggly' formant motion.
+# - .number_of_formants: The best analysis will be found on average across all desired
+#      formants. Often, F4 can be difficult to track so that the best analysis including F4.
+# - .tracking_method$: "burg" or "robust"
+# - .image: image to show after analysis is complete - values can be:
+#      0: Don't show an image
+#      1: Show image of winner
+#      2: Show image comparing of all analyses
+# - .snd_to_plot: sound object for plotting.
+# - .plot_current_view: if image > 0, whether to plot the view of the current window (1) or not (0)
+# - .maximum_plotting_frequency: if image > 0, maximum frequency for image.
+# - .output_formant: how to return the winning formant object - values can be:
+#      0: Don't return the winning formant
+#      1: Save a formant object to a file named after the sound
+#      2: Leave a formant object named after the sound in the Objects list
+#      3: Both 1 and 2
+# - .output_table: how to return the table of winning formant measurements - values can be:
+#      0: Don't return the winning formant
+#      1: Save the measurements to a CVS file named after the sound
+#      2: Leave a table object named after the sound in the Objects list
+#      3: Both 1 and 2
+# - .output_all_candidates: how to return all formant objects - values can be:
+#      0: Don't return the all candidate formants
+#      1: Save all formant candidates to files named after the sound
+# outputs:
+# Apart from the output objects/files specified by the parameters, the procedure also sets the
+# following output variabls:
+# - trackAutoselect.cutoff
+# - trackAutoselect.f1coeffs# - Vector of coefficients for F1
+# - trackAutoselect.f2coeffs# - Vector of coefficients for F2
+# - trackAutoselect.f3coeffs# - Vector of coefficients for F3
+# - trackAutoselect.f4coeffs# - Vector of coefficients for F4 (if .number_of_formants = 4)
+
+procedure trackAutoselect: .snd, .folder$, .lowest_analysis_frequency, .highest_analysis_frequency, .number_of_steps, .number_of_coefficients_for_formant_prediction, .number_of_formants, .tracking_method$, .image, .snd_to_plot, .plot_current_view, .maximum_plotting_frequency, .output_formant, .output_table, .output_all_candidates
+
+  # make sure the given sound object is selected
+  selectObject: .snd
+  .basename$ = selected$ ("Sound")
+  
+  ########################################################################################################################################################
+  ########################################################################################################################################################
+  ## Error estimation section
+  
+  # error related variables
+  # this is a global variable output from modeling/findError
+  formantError# = zero#(.number_of_formants)
+  .minerror = 999999
+  .error# =  zero# (.number_of_steps)
+  .cutoffs# = zero#(.number_of_steps)
+  
+  # determine analysis frequencies given number of steps and cutoffs
+  .stepSize = (.highest_analysis_frequency-.lowest_analysis_frequency) / (.number_of_steps-1)
+  for i from 1 to .number_of_steps
+    .cutoffs#[i] = round (.lowest_analysis_frequency+.stepSize*(i-1))
+  endfor
+    
+  .winner = 1
+  
+  ## loop that performs the analyses
+  for z from 1 to .number_of_steps
+    selectObject: .snd
+  
+    # analysis of sounds
+    if .tracking_method$ == "burg"
+      noprogress To Formant (burg): time_step, 5.5, .cutoffs#[z], 0.025, 50
+    endif
+    if .tracking_method$ == "robust"
+      noprogress To Formant (robust): time_step, 5.5, .cutoffs#[z], 0.025, 50, 1.5, 5, 1e-006
+    endif
+    Rename: "formants_" + string$(z)
+    .formantObject = selected ("Formant")
+  
+    # this is where the contours actually get modeled. check this function out for info.
+    # it also created a lot of useful variables like the coefficient and error vectors that get used below.
+    # in praat these are all global variables, functions dont return results. 
+    @findError: .formantObject, .number_of_coefficients_for_formant_prediction
+    Rename: "formants_" + string$(z)
+  
+    # if current step minimizes the error, make it the new winner
+    if .error#[z] <  .minerror
+      .winner = z
+      .cutoff = .cutoffs#[z]
+      .minerror = .error#[z]
+  
+      # store regression coefficients for output in info window
+      # TODO f1coeffs#, f2coeffs#, f3coeffs#, f4coeffs# are outputs of findError
+      .f1coeffs# = f1coeffs#
+      .f2coeffs# = f2coeffs#
+      .f3coeffs# = f3coeffs#
+      if .number_of_formants == 4
+        .f4coeffs# = f4coeffs#
+      endif
+    endif
+  
+    .error#[z] = sum(formantError#)
+    .error#[z] = round (.error#[z] * 10) / 10
+    
+  endfor
+    
+  ########################################################################################################################################################
+  ########################################################################################################################################################
+  ## Plot
+  
+  if .image = 1
+    Erase all
+    Select outer viewport: 0, 7.5, 0, 4.5
+    selectObject: "Table formants_" + string$(.winner)
+    .tbl = selected ("Table")
+    selectObject: .snd_to_plot
+  
+    ## if NOT current view
+    if .plot_current_view = 0
+      .sp = To Spectrogram: 0.007, .maximum_plotting_frequency, 0.002, 5, "Gaussian"
+      @plotTable: .sp, .tbl, .maximum_plotting_frequency, 1, "Maximum formant = " + string$(.cutoff) + " Hz"
+      removeObject: .sp
+    endif
+  
+    # if YEs current view, this needs to grab the current spectrogram from the view window and plot it.
+    # analysis also needs to be scaled to the frequency limit of the view so that these match. 
+    if .plot_current_view = 1
+      editor: .snd_to_plot 
+      .sp = Extract visible spectrogram
+      info$ = Editor info
+      .maximum_plotting_frequency = extractNumber (info$, "Spectrogram view to: ")
+      endeditor
+      selectObject: .sp
+      @plotTable: .sp, .tbl, .maximum_plotting_frequency, 1, "Maximum formant = " + string$(.cutoff) + " Hz"
+      removeObject: .sp
+    endif
+    # change to save with filename or not
+    Save as 300-dpi PNG file: .folder$ + "/file_winner.png"
+  endif
+  
+  # this is for the comparison images. pretty straightforward
+  if .image = 2
+    Erase all
+    selectObject: .snd_to_plot
+   
+    .sp = To Spectrogram: 0.007, .maximum_plotting_frequency, 0.002, 5, "Gaussian"
+  
+    width = 2.85
+    .xlims# = {0,width, width*2,width*3,0,width, width*2,width*3,0,width, width*2, width*3,0,width, width*2, width*3,0,width, width*2, width*3,0,width, width*2, width*3}
+    .ylims# = {0,0,0,0,2,2,2,2,4,4,4,4,6,6,6,6,8,8,8,8,10,10,10,10}
+    
+    for z from 1 to .number_of_steps
+      Select outer viewport: .xlims#[z], .xlims#[z]+3.2, .ylims#[z], .ylims#[z]+2
+      selectObject: "Table formants_" + string$(z)
+      .tbl = selected ("Table")
+      Font size: 8
+      @plotTable: .sp, .tbl, .maximum_plotting_frequency, 1, "Maximum formant = " + string$(.cutoffs#[z]) + " Hz"
+  
+      if z = .winner
+         Line width: 4
+         Draw inner box
+         Line width: 1
+      endif
+    endfor
+  
+    Font size: 10
+    if .number_of_steps = 8
+      Select outer viewport: 0, 12, 0, 4
+    elsif .number_of_steps = 12
+      Select outer viewport: 0, 12, 0, 6
+    elsif .number_of_steps = 16
+      Select outer viewport: 0, 12, 0, 8
+    elsif .number_of_steps = 20
+      Select outer viewport: 0, 12, 0, 10
+    elsif .number_of_steps = 24
+      Select outer viewport: 0, 12, 0, 12
+    endif
+    Save as 300-dpi PNG file: .folder$ + "/file_comparison.png"
+  endif
+  nocheck removeObject: .sp
+  
+  ########################################################################################################################################################
+  ########################################################################################################################################################
+  ## Save data and delete backup files. nothing fancy here. a lot of removing objects
+  
+  
+  for z from 1 to .number_of_steps
+  	# (.output_...: 1=save, 2=return, 3=both)
+  	if (.output_formant = 1 or .output_formant = 3 or .output_all_candidates = 1) and z = .winner
+  		selectObject: "Formant formants_" + string$(z)
+  		Save as short text file: .folder$ + "/" + .basename$ + "_" + string$(.winner) +"_.Formant"
+  	endif
+  	if .output_all_candidates = 1 and z <> .winner
+  		selectObject: "Formant formants_" + string$(z)
+  		Save as short text file: .folder$ + "/" + .basename$ + "_" + string$(z) +"_.Formant"
+  	endif
+  endfor
+
+  # (.output_...: 1=save, 2=return, 3=both)
+  if .output_table > 0
+    selectObject: "Table formants_" + string$(.winner)
+    .tbl = selected ("Table")
+    @addAcousticInfoToTable: .tbl, .snd  
+    
+    for .i from 1 to .number_of_formants
+      if output_bandwidth == 0
+        Remove column... b'.i'
+      endif
+      if output_predictions == 0
+        Remove column... f'.i'p
+      endif
+    endfor
+  
+    if output_normalized_time == 0
+      Insert column: 2, "ntime"
+      Formula: "ntime", "row / nrow"
+    endif
+  
+  endif
+
+  # (.output_...: 1=save, 2=return, 3=both)
+  if .output_table = 1 or .output_table = 3
+  	selectObject: "Table formants_" + string$(.winner)
+  	Save as comma-separated file: .folder$ + "/" + .basename$ + ".csv"
+  endif  
+  if .output_table >= 2
+  	selectObject: "Table formants_" + string$(.winner)
+  	Rename: .basename$
+  else
+  	selectObject: "Table formants_" + string$(.winner)
+  	Remove
+  endif
+  
+  for z from 1 to .number_of_steps
+   if z = .winner
+  	 # (.output_...: 1=save, 2=return, 3=both)
+  	 if .output_formant >= 2
+  		 selectObject: "Formant formants_" + string$(z)
+  		 Rename: .basename$
+  	 endif
+   endif
+   nocheck removeObject: "Formant formants_" + string$(z)
+   nocheck removeObject: "Table formants_" + string$(z)
+  endfor
+    
+endproc


### PR DESCRIPTION
Splits non-interactive parts of `file_1_trackAutoselect.praat` out into `utils/trackAutoselectProcedure.praat`, which defines a non-interactive procedure for analysing a single speech sample.
The procedure has (hopefully) well-defined inputs and outputs, so that, in addition to still working as before,  an unsupervised script can also call it (repeatedly) without user input, extracting whatever output is required.

The following is an example of usage of the procedure:
```
# set up
include utils/trackAutoselectProcedure.praat
@getSettings

# get some audio to analyse
Open long sound file... /path/to/recording.wav
Extract part... 2.79 3.04 0

# parameters for procedure - in this case, we just want the winning formant object
dir$ = "/home/robert/nzilbb/FastTrack/test"
min = 4700
max = 7550
steps = 20
coefficients = 5
formants = 3
tracking_method$ = "burg"
image = 0
max_plot = 4000 
out_formant = 2
out_table = 0
out_all = 0
current_view = 0

# call the procedure to analyse the speech
@trackAutoselect: selected(), dir$, min, max, steps, coefficients, formants, method$, image, selected(), current_view, max_plot, out_formant, out_table, out_all

# do something with the output, e.g...

# print coefficients
print F1 coefficients: 
for c from 1 to coefficients + 1
  coefficient = trackAutoselect.f1coeffs#[c]
  print 'coefficient:0'
  print ,
endfor
printline
print F2 coefficients: 
for c from 1 to coefficients + 1
  coefficient = trackAutoselect.f2coeffs#[c]
  print 'coefficient:0'
  print ,
endfor
printline

# get F1 at mid-point
result = Get value at time... 1 0.125 Hertz Linear
print F1 at midpoint: 
print 'result:0'
printline
Remove

```