### PR TITLE
In Track Folder, make info window optional

### DIFF
--- a/Fast Track/functions/folder/autoSelectFolder.praat
+++ b/Fast Track/functions/folder/autoSelectFolder.praat
@@ -94,21 +94,25 @@ procedure autoSelectFolder
     selectObject: .file_info 
     .basename$ = Get value: .ii, "file"
     .basename$ = .basename$ - ".wav"
-    writeInfoLine: "Selecting winners (step 2): " +string$(.ii) +" of " + string$(.nfiles) + ", " + .basename$
+	
+	##Optionally show progress
+	if show_progress
+		writeInfoLine: "Selecting winners (step 2): " +string$(.ii) +" of " + string$(.nfiles) + ", " + .basename$
 
-    ## timing part
-    if .ii > 10 and .nfiles > 60
-      @daySecond
-      .nowSecond = daySecond
-      .elapsedTime = .nowSecond - .startSecond
-      .totalTime = .elapsedTime * (.nfiles / .ii)
-      .endGuess = .totalTime - .elapsedTime
-      .endGuess = round (.endGuess / 60) ; minus elapsed time?
-      appendInfoLine: "Process should take about " + string$(.endGuess) + " more minutes at current rate."
-      #appendInfoLine: .totalTime
-      #appendInfoLine: .elapsedTime
-    endif
-
+		## timing part
+		if .ii > 10 and .nfiles > 60
+		  @daySecond
+		  .nowSecond = daySecond
+		  .elapsedTime = .nowSecond - .startSecond
+		  .totalTime = .elapsedTime * (.nfiles / .ii)
+		  .endGuess = .totalTime - .elapsedTime
+		  .endGuess = round (.endGuess / 60) ; minus elapsed time?
+		  appendInfoLine: "Process should take about " + string$(.endGuess) + " more minutes at current rate."
+		  #appendInfoLine: .totalTime
+		  #appendInfoLine: .elapsedTime
+		endif
+	endif
+	
     # read in sound and make spectrogram
     .snd = Read from file: folder$ +"/sounds/" + .basename$+ ".wav"
     if save_image = 1

--- a/Fast Track/functions/folder/getWinnersFolder.praat
+++ b/Fast Track/functions/folder/getWinnersFolder.praat
@@ -88,16 +88,19 @@ procedure getWinnersFolder
 	  if number_of_formants == 4
 	 		Set string: 11, string$(.wf1)+" "+string$(.wf2)+" "+string$(.wf3)+" "+string$(.wf4)
 	  endif
-
-	  writeInfoLine: "Getting winners (step 3): " + string$(.counter) +" of " + string$(.nfiles) + ", " + .basename$
-	  if .counter > 10 and .nfiles > 60
-			daySecond = 0
-			@daySecond
-			.nowSecond = daySecond
-			.elapsedTime = .nowSecond - .startSecond
-	    .totalTime = .elapsedTime * (.nfiles / .counter)
-	    .endGuess = round (.totalTime / 60)
-	    appendInfoLine: "Process should take about " + string$(.endGuess) + " more minutes at current rate."
+	  
+	  ##Optionally show progress
+	  if show_progress
+		  writeInfoLine: "Getting winners (step 3): " + string$(.counter) +" of " + string$(.nfiles) + ", " + .basename$
+		  if .counter > 10 and .nfiles > 60
+				daySecond = 0
+				@daySecond
+				.nowSecond = daySecond
+				.elapsedTime = .nowSecond - .startSecond
+			.totalTime = .elapsedTime * (.nfiles / .counter)
+			.endGuess = round (.totalTime / 60)
+			appendInfoLine: "Process should take about " + string$(.endGuess) + " more minutes at current rate."
+		  endif
 	  endif
 
 		

--- a/Fast Track/functions/folder/trackFolder.praat
+++ b/Fast Track/functions/folder/trackFolder.praat
@@ -36,14 +36,16 @@ procedure trackFolder
       .basename$ = .basename$ - ".wav"
 
       ## message about expected computing time
-      writeInfoLine: "Tracking formants (step 1): " + string$(.iii) +" of " + string$(.nfiles) + ", " + .basename$
-      if .iii > 10 and .nfiles > 60
-        @daySecond
-        .nowSecond = daySecond
-        .elapsedTime = .nowSecond - .startSecond
-        .totalTime = .elapsedTime * (.nfiles / .iii)
-        .endGuess = round (.totalTime / 60)
-        appendInfoLine: "Process should take about " + string$(.endGuess) + " more minutes at current rate."
+	  if show_progress
+		  writeInfoLine: "Tracking formants (step 1): " + string$(.iii) +" of " + string$(.nfiles) + ", " + .basename$
+		  if .iii > 10 and .nfiles > 60
+			@daySecond
+			.nowSecond = daySecond
+			.elapsedTime = .nowSecond - .startSecond
+			.totalTime = .elapsedTime * (.nfiles / .iii)
+			.endGuess = round (.totalTime / 60)
+			appendInfoLine: "Process should take about " + string$(.endGuess) + " more minutes at current rate."
+		  endif
       endif
 
       for .z from 1 to number_of_steps

--- a/Fast Track/functions/folder_1_analyzeFolder.praat
+++ b/Fast Track/functions/folder_1_analyzeFolder.praat
@@ -60,6 +60,7 @@ beginPause: "Set Parameters"
     optionMenu: "Statistic", 1
   	        option: "median"
   					option: "mean"
+	boolean: "Show progress", 0
      optionMenu: "", 1
     option: "[Click to Read]"
    option: "Uncheck to skip step. Individual steps can be carried out if previous step has been completed."


### PR DESCRIPTION
Adds a new "Show progress" boolean option to the Track Folder pause window. When `show_progress = 1`, usual behavior is maintained. When `show_progress = 0`, the for-looped `writeInfoLine`/`appendInfoLine` calls are avoided in all the `folder/` scripts, freeing up the computer for background work while Fast Track is running.

This fix doesn't affect the Picture window repeatedly coming into focus during image-creation steps, but the user can regain control by minimizing the Picture window when it comes into focus.