### PR TITLE
Create sound folder when maintaining separate files

### DIFF
--- a/Fast Track/functions/tools/extractVowelswithTG.praat
+++ b/Fast Track/functions/tools/extractVowelswithTG.praat
@@ -239,6 +239,7 @@ for filecounter from 1 to nfiles
       
       if maintain_separate == 1
           createDirectory: output_folder$ + "/" + basename$
+          createDirectory: output_folder$ + "/" + basename$ + "/sounds"
       endif
       if maintain_separate == 0
           createDirectory: output_folder$ + "/sounds"
@@ -248,9 +249,9 @@ for filecounter from 1 to nfiles
 
       if maintain_separate == 1
         selectObject: file_info
-        Save as comma-separated file: output_folder$ + "/"+ basename$+ "_file_information.csv"
+        Save as comma-separated file: output_folder$ + "/"+ basename$ + "/" + "file_information.csv"
         selectObject: tbl
-        Save as comma-separated file: output_folder$ + "/"+ basename$+ "_segmentation_info.csv"
+        Save as comma-separated file: output_folder$ + "/"+ basename$ + "/" + "segmentation_info.csv"
       endif
       
       selectObject: tbl

--- a/Fast Track/functions/utils/extractVowels.praat
+++ b/Fast Track/functions/utils/extractVowels.praat
@@ -161,7 +161,7 @@ procedure extractVowels
         endif
 
         if maintain_separate == 1
-          Save as WAV file: output_folder$ + "/" + basename$ + "/" + filename$ + ".wav"
+          Save as WAV file: output_folder$ + "/" + basename$ + "/sounds/" + filename$ + ".wav"
         endif
         if maintain_separate == 0
           Save as WAV file: output_folder$ + "/sounds/" + filename$ + ".wav"


### PR DESCRIPTION
Hi! Thanks for this amazing tool! This is a PR to merge the following changes:

- When the `Maintain separate files and information` in the `Extract vowels with TextGrids` is checked, the vowel files are now saved in a `sounds/` folder so that the `Track folder` function can be used out of the box.
- The `file_information` and `segmentation_info` files are now saved in each folder so that they can be picked up by the `Track folder` function.

These changes allow one to use the `Track folder` function directly on the folders of the individual original files (this is convenient when different files belong to different speakers, so that the `Track folder` function can be run on the vowel files of a single speaker to find the best analysis settings for that speaker).